### PR TITLE
Feature integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+# Development
+
+## Testing
+
+To run tests issue the following command in the root of the project:
+
+```bash
+go test -p 1 ./...
+```
+
+The `-p 1` is needed to prevent tests from being run in parallel. To re-run the tests first run the following:
+
+```bash
+go clean -testcache
+```
+
+To skip the integration tests use the `-short` flag:
+
+```bash
+go test -p 1 -short ./...
+```
+
 # Javascript Execution Activity
 
 The `jsexec` activity evaluates a javascript `script` along with provided `parameters` and returns the result in the `outputs`.

--- a/examples/microgateway/api/main.go
+++ b/examples/microgateway/api/main.go
@@ -1,49 +1,12 @@
 package main
 
 import (
-	trigger "github.com/project-flogo/contrib/trigger/rest"
-	"github.com/project-flogo/core/api"
 	"github.com/project-flogo/core/engine"
-	"github.com/project-flogo/jsexec"
-	"github.com/project-flogo/microgateway"
-	microapi "github.com/project-flogo/microgateway/api"
+	tests "github.com/project-flogo/jsexec/examples/microgateway"
 )
 
 func main() {
-	app := api.NewApp()
-
-	gateway := microapi.New("JS")
-
-	service := gateway.NewService("JS", &jsexec.Activity{})
-	service.SetDescription("Calculate sum")
-	service.AddSetting("script", "result.sum = parameters.a + parameters.b")
-
-	step := gateway.NewStep(service)
-	step.AddInput("parameters", map[string]interface{}{"a": 1.0, "b": 2.0})
-
-	response := gateway.NewResponse(false)
-	response.SetCode(200)
-	response.SetData("=$.JS.outputs.result")
-	settings, err := gateway.AddResource(app)
-	if err != nil {
-		panic(err)
-	}
-
-	trg := app.NewTrigger(&trigger.Trigger{}, &trigger.Settings{Port: 9096})
-	handler, err := trg.NewHandler(&trigger.HandlerSettings{
-		Method: "GET",
-		Path:   "/calculate",
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	_, err = handler.NewAction(&microgateway.Action{}, settings)
-	if err != nil {
-		panic(err)
-	}
-
-	e, err := api.NewEngine(app)
+	e, err := tests.Example()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/microgateway/examples.go
+++ b/examples/microgateway/examples.go
@@ -1,0 +1,48 @@
+package microgateway
+
+import (
+	trigger "github.com/project-flogo/contrib/trigger/rest"
+	"github.com/project-flogo/core/api"
+	"github.com/project-flogo/core/engine"
+	"github.com/project-flogo/jsexec"
+	"github.com/project-flogo/microgateway"
+	microapi "github.com/project-flogo/microgateway/api"
+)
+
+// Example returns an API example
+func Example() (engine.Engine, error) {
+	app := api.NewApp()
+
+	gateway := microapi.New("JS")
+
+	service := gateway.NewService("JS", &jsexec.Activity{})
+	service.SetDescription("Calculate sum")
+	service.AddSetting("script", "result.sum = parameters.a + parameters.b")
+
+	step := gateway.NewStep(service)
+	step.AddInput("parameters", map[string]interface{}{"a": 1.0, "b": 2.0})
+
+	response := gateway.NewResponse(false)
+	response.SetCode(200)
+	response.SetData("=$.JS.outputs.result")
+	settings, err := gateway.AddResource(app)
+	if err != nil {
+		return nil, err
+	}
+
+	trg := app.NewTrigger(&trigger.Trigger{}, &trigger.Settings{Port: 9096})
+	handler, err := trg.NewHandler(&trigger.HandlerSettings{
+		Method: "GET",
+		Path:   "/calculate",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = handler.NewAction(&microgateway.Action{}, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.NewEngine(app)
+}

--- a/examples/microgateway/examples_test.go
+++ b/examples/microgateway/examples_test.go
@@ -1,0 +1,101 @@
+package microgateway
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/project-flogo/core/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func Drain(port string) {
+	for {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort("", port), time.Second)
+		if conn != nil {
+			conn.Close()
+		}
+		if err != nil && strings.Contains(err.Error(), "connect: connection refused") {
+			break
+		}
+	}
+}
+
+func Pour(port string) {
+	for {
+		conn, _ := net.Dial("tcp", net.JoinHostPort("", port))
+		if conn != nil {
+			conn.Close()
+			break
+		}
+	}
+}
+
+// Response is a reply form the server
+type Response struct {
+	Sum float64 `json:"sum"`
+}
+
+func testApplication(t *testing.T, e engine.Engine) {
+	Drain("9096")
+	err := e.Start()
+	assert.Nil(t, err)
+	defer func() {
+		err := e.Stop()
+		assert.Nil(t, err)
+	}()
+	Pour("9096")
+
+	transport := &http.Transport{
+		MaxIdleConns: 1,
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{
+		Transport: transport,
+	}
+	request := func() Response {
+		req, err := http.NewRequest(http.MethodGet, "http://localhost:9096/calculate", nil)
+		assert.Nil(t, err)
+		response, err := client.Do(req)
+		assert.Nil(t, err)
+		body, err := ioutil.ReadAll(response.Body)
+		assert.Nil(t, err)
+		response.Body.Close()
+		rsp := Response{}
+		err = json.Unmarshal(body, &rsp)
+		assert.Nil(t, err)
+		return rsp
+	}
+
+	response := request()
+	assert.Equal(t, 3.0, response.Sum)
+}
+
+func TestIntegrationAPI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping API integration test in short mode")
+	}
+
+	e, err := Example()
+	assert.Nil(t, err)
+	testApplication(t, e)
+}
+
+func TestIntegrationJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping JSON integration test in short mode")
+	}
+
+	data, err := ioutil.ReadFile(filepath.FromSlash("./json/flogo.json"))
+	assert.Nil(t, err)
+	cfg, err := engine.LoadAppConfig(string(data), false)
+	assert.Nil(t, err)
+	e, err := engine.New(cfg)
+	assert.Nil(t, err)
+	testApplication(t, e)
+}


### PR DESCRIPTION
To run tests issue the following command in the root of the project:

```bash
go test -p 1 ./...
```

The `-p 1` is needed to prevent tests from being run in parallel. To re-run the tests first run the following:

```bash
go clean -testcache
```

To skip the integration tests use the `-short` flag:

```bash
go test -p 1 -short ./...